### PR TITLE
Bugfix infinite loop when only having upload input

### DIFF
--- a/src/Endpoint/JobsEndpoint.php
+++ b/src/Endpoint/JobsEndpoint.php
@@ -92,7 +92,13 @@ class JobsEndpoint extends Abstracted
         );
 
         if ($withUpload) {
-            $job = $this->waitStatus($job['id'], [self::STATUS_READY]);
+            $statusToWait = [self::STATUS_READY];
+
+            if (count($remoteInput) == 0) {
+                $statusToWait[] = self::STATUS_INCOMPLETE;
+            }
+
+            $job = $this->waitStatus($job['id'], $statusToWait);
 
             foreach ($uploadInput as $key => $input) {
                 $this->postFile($input, $job);


### PR DESCRIPTION
The ready status will never be reached if we create a job with only one upload input, that's why when we don't have any remote input we can wait until incomplete status.