### PR TITLE
Fixed status loop

### DIFF
--- a/src/Endpoint/Abstracted.php
+++ b/src/Endpoint/Abstracted.php
@@ -48,6 +48,8 @@ class Abstracted
 
     /**
      * @param string $userToken
+     *
+     * @return $this
      */
     public function setUserToken($userToken)
     {

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OnlineConvert\Exception;
+
+/**
+ * Throwable when the requested method receives bad arguments.
+ *
+ * @package OnlineConvert\Exception
+ */
+class InvalidArgumentException extends OnlineConvertSdkException
+{
+}

--- a/src/Exception/InvalidStatusException.php
+++ b/src/Exception/InvalidStatusException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OnlineConvert\Exception;
+
+/**
+ * Throwable when the requested status cannot be used in the actual context.
+ * E.g. if you try to patch a completed job
+ *
+ * @package OnlineConvert\Exception
+ */
+class InvalidStatusException extends OnlineConvertSdkException
+{
+}

--- a/src/Exception/JobNotFoundException.php
+++ b/src/Exception/JobNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OnlineConvert\Exception;
+
+/**
+ * Throwable when the job is not found
+ *
+ * @package OnlineConvert\Exception
+ */
+class JobNotFoundException extends OnlineConvertSdkException
+{
+}

--- a/src/Exception/StatusUnknownException.php
+++ b/src/Exception/StatusUnknownException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OnlineConvert\Exception;
+
+/**
+ * Throwable when the requested job status is unknown
+ *
+ * @package OnlineConvert\Exception
+ */
+class StatusUnknownException extends OnlineConvertSdkException
+{
+}

--- a/src/Handler/CallbackHandler.php
+++ b/src/Handler/CallbackHandler.php
@@ -1,19 +1,16 @@
 <?php
 namespace OnlineConvert\Handler;
 
-use OnlineConvert\Endpoint\JobsEndpoint;
 use OnlineConvert\Exception\JobFailedException;
+use OnlineConvert\Model\JobStatus;
 
 /**
  * Manage callbacks when the job finish given by the api
  *
  * @package OnlineConvert\Handler
- *
- * @author Andrés Cevallos <a.cevallos@qaamgo.com>
  */
 class CallbackHandler
 {
-
     /**
      * Check if the job given have status completed
      *
@@ -25,7 +22,7 @@ class CallbackHandler
      */
     public function jobHasExpectedStatus(array $job)
     {
-        if ($job['status']['code'] != JobsEndpoint::STATUS_COMPLETED) {
+        if ($job['status']['code'] != JobStatus::STATUS_COMPLETED) {
             $jobId = $job['id'];
             throw new JobFailedException("the job '$jobId' has not been completed successfully");
         }

--- a/src/Model/JobStatus.php
+++ b/src/Model/JobStatus.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace OnlineConvert\Model;
+
+use OnlineConvert\Exception\StatusUnknownException;
+
+/**
+ * Class Status
+ *
+ * @package OnlineConvert\Model
+ */
+class JobStatus
+{
+    /**
+     * Status when the job is incomplete waiting for information to be ready or processed
+     *
+     * @const string
+     */
+    const STATUS_INCOMPLETE = 'incomplete';
+
+    /**
+     * Status when the job is ready to begin process
+     *
+     * @const string
+     */
+    const STATUS_READY = 'ready';
+
+    /**
+     * Status when the job is downloading the input files
+     *
+     * @const string
+     */
+    const STATUS_DOWNLOADING = 'downloading';
+
+    /**
+     * Status when the job is processing the job
+     *
+     * @const string
+     */
+    const STATUS_PROCESSING = 'processing';
+
+    /**
+     * Status when the job fails
+     *
+     * @const string
+     */
+    const STATUS_FAILED = 'failed';
+
+    /**
+     * Status when the job completes correctly
+     *
+     * @const string
+     */
+    const STATUS_COMPLETED = 'completed';
+
+    /**
+     * The status ranking list.
+     * A status can be updated only if the new one is at the same or at a higher ranking level.
+     *
+     * @var array
+     */
+    private $statusesRanking = [
+        self::STATUS_INCOMPLETE  => 1,
+        self::STATUS_READY       => 2,
+        self::STATUS_DOWNLOADING => 2,
+        self::STATUS_PROCESSING  => 3,
+        self::STATUS_FAILED      => 4,
+        self::STATUS_COMPLETED   => 5,
+    ];
+
+    /**
+     * The status code
+     *
+     * @var string
+     */
+    private $code;
+
+    /**
+     * The status ranking level
+     *
+     * @var integer
+     */
+    private $rank;
+
+    /**
+     * Status constructor.
+     *
+     * @param string $statusCode
+     */
+    public function __construct($statusCode)
+    {
+        if (empty($this->statusesRanking[$statusCode])) {
+            throw new StatusUnknownException('Unknown status: ' . $statusCode);
+        }
+
+        $this->code = $statusCode;
+        $this->rank = $this->statusesRanking[$statusCode];
+    }
+
+    /**
+     * Checks if the job status can be updated with the passed one
+     *
+     * @param JobStatus $newStatus    The new desired status
+     *
+     * @return boolean                True when it is possible to update the actual status with the passed one
+     *
+     * @throws StatusUnknownException When one of the passed statuses is unknown
+     */
+    public function canBeUpdated(JobStatus $newStatus)
+    {
+        return ($newStatus->getRank() >= $this->rank);
+    }
+
+    /**
+     * Checks if the status is equal to the one passed (one of self::STATUS_*)
+     *
+     * @param string $status
+     *
+     * @return boolean
+     */
+    public function isStatus($status)
+    {
+        return ($this->code === $status);
+    }
+
+    /**
+     * Checks if the status is completed
+     *
+     * @return boolean
+     */
+    public function isCompleted()
+    {
+        return ($this->code === self::STATUS_COMPLETED);
+    }
+
+    /**
+     * Checks if the status is failed
+     *
+     * @return boolean
+     */
+    public function isFailed()
+    {
+        return ($this->code === self::STATUS_FAILED);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getRank()
+    {
+        return $this->rank;
+    }
+}

--- a/tests/Endpoint/Abstracted.php
+++ b/tests/Endpoint/Abstracted.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Test\OnlineConvert\Endpoint;
+
+use OnlineConvert\Client\Interfaced;
+
+class Abstracted extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $clientMock;
+
+    /**
+     * A Job id in UUID format
+     *
+     * @var string
+     */
+    protected $aJobId = '00000000-1111-2222-3333-444444444444';
+
+    /**
+     * A Conversion id in UUID format
+     *
+     * @var string
+     */
+    protected $aConversionId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+    /**
+     * A token
+     *
+     * @var string
+     */
+    protected $aToken = '01234567890123456789012345678901';
+
+    /**
+     * A server URL
+     *
+     * @var string
+     */
+    protected $aServer = 'http://www4.online-convert.com';
+
+    /**
+     * Method called before starting each test
+     */
+    public function setUp()
+    {
+        $this->clientMock = $this->getMockBuilder(Interfaced::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Method called at the end of each test
+     */
+    public function tearDown()
+    {
+        unset($this->clientMock);
+    }
+
+    /**
+     * To be used while checking for invalid arguments to be sure that no HTTP API requests are sent
+     */
+    protected function setClientMockToNeverCallMethods()
+    {
+        $this->clientMock
+            ->expects($this->never())
+            ->method('generateUrl');
+        $this->clientMock
+            ->expects($this->never())
+            ->method('sendRequest');
+    }
+}

--- a/tests/Endpoint/JobsEndpointTest.php
+++ b/tests/Endpoint/JobsEndpointTest.php
@@ -1,0 +1,379 @@
+<?php
+
+namespace Test\OnlineConvert\Endpoint;
+
+use OnlineConvert\Client\Interfaced;
+use OnlineConvert\Client\Resources as ClientResources;
+use OnlineConvert\Endpoint\JobsEndpoint;
+use OnlineConvert\Endpoint\Resources;
+
+/**
+ * Class JobsEndpointTest
+ * @package Test\OnlineConvert\Endpoint
+ */
+class JobsEndpointTest extends Abstracted
+{
+    /**
+     * @var JobsEndpoint
+     */
+    private $jobsEndpoint;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->jobsEndpoint = new JobsEndpoint($this->clientMock);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        unset($this->jobsEndpoint);
+    }
+
+    public function testWaitStatusForMatchedSingleStatus()
+    {
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"ready"}}');
+
+        $response = $this->jobsEndpoint->waitStatus($this->aJobId, ['ready']);
+
+        $this->assertEquals('ready', $response['status']['code']);
+    }
+
+    public function testWaitStatusForMatchedMultipleStatuses()
+    {
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"downloading"}}');
+
+        $response = $this->jobsEndpoint->waitStatus($this->aJobId, ['ready', 'downloading', 'completed']);
+
+        $this->assertEquals('downloading', $response['status']['code']);
+    }
+
+    public function testWaitStatusForLowerStatus()
+    {
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"processing"}}');
+
+        $this->expectException('OnlineConvert\Exception\InvalidStatusException');
+        $this->expectExceptionMessage(
+            'The awaited status ready can never be reached since the actual status is processing'
+        );
+
+        $this->jobsEndpoint->waitStatus($this->aJobId, ['ready']);
+    }
+
+    public function testWaitStatusForLowerStatusButJobFailed()
+    {
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"failed"}}');
+
+        $this->expectException('OnlineConvert\Exception\JobFailedException');
+        $this->expectExceptionMessage(
+            '"{\"id\":\"' . $this->aJobId . '\",\"status\":{\"code\":\"failed\"}}"'
+        );
+
+        $this->jobsEndpoint->waitStatus($this->aJobId, ['completed']);
+    }
+
+    public function testWaitStatusForHigherStatus()
+    {
+        $this->clientMock
+            ->expects($this->at(0))
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"downloading"}}');
+        $this->clientMock
+            ->expects($this->at(1))
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"processing"}}');
+        $this->clientMock
+            ->expects($this->at(2))
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"completed"}}');
+
+        $response = $this->jobsEndpoint->waitStatus($this->aJobId, ['completed']);
+
+        $this->assertEquals('completed', $response['status']['code']);
+    }
+
+    public function testWaitStatusForTimeoutException()
+    {
+        $waitingTimeBetweenRequests = 1;
+        $timeout                    = 2;
+
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"ready"}}');
+
+        $this->expectException('OnlineConvert\Exception\OnlineConvertSdkException');
+        $this->expectExceptionMessage('Timeout reached while waiting for the Job status');
+
+        $response = $this->jobsEndpoint->waitStatus(
+            $this->aJobId,
+            ['completed'],
+            $waitingTimeBetweenRequests,
+            $timeout
+        );
+
+        $this->assertEquals('ready', $response['status']['code']);
+    }
+
+    public function testPostFullJobWithEmptyJob()
+    {
+        $this->expectException('OnlineConvert\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The Job is empty');
+
+        $this->setClientMockToNeverCallMethods();
+
+        $this->jobsEndpoint->postFullJob([]);
+    }
+
+    public function testPostFullJobWithEmptyInput()
+    {
+        $job = [
+            'process' => false,
+        ];
+
+        $this->setClientMockToNeverCallMethods();
+
+        $this->expectException('OnlineConvert\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage(
+            'It is not possible to use OnlineConvert\Endpoint\JobsEndpoint::postFullJob with no input. ' .
+            'Please, use OnlineConvert\Endpoint\JobsEndpoint::postIncompleteJob instead.'
+        );
+
+        $this->jobsEndpoint->postFullJob($job);
+    }
+
+    public function testPostFullJobAsyncWithoutCallback()
+    {
+        $job = [
+            'process' => false,
+            'input' => [
+                [
+                    'type'   => 'remote',
+                    'source' => 'http://www.online-convert.com',
+                ],
+            ],
+        ];
+
+        $this->setClientMockToNeverCallMethods();
+
+        $this->expectException('OnlineConvert\Exception\CallbackNotDefinedException');
+        $this->expectExceptionMessage('Async jobs must have a valid callback url to notify when the job finish');
+
+        $this->jobsEndpoint->setAsync(true);
+        $this->jobsEndpoint->postFullJob($job);
+    }
+
+    public function testPostFullJobWithRemoteInput()
+    {
+        $job = [
+            'process' => true,
+            'input' => [
+                [
+                    'type'   => 'remote',
+                    'source' => 'http://www.online-convert.com',
+                ],
+            ],
+        ];
+
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"completed"}}');
+
+        $this->jobsEndpoint->postFullJob($job);
+    }
+
+    public function testPostIncompleteSyncJobWillChangeProcessToFalse()
+    {
+        $job = [
+            'process' => true,
+        ];
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(Resources::JOB, Interfaced::METHOD_POST, ['process' => false]);
+
+        $this->jobsEndpoint->postIncompleteJob($job);
+    }
+
+    public function testGetJobs()
+    {
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                Resources::JOB,
+                Interfaced::METHOD_GET,
+                null,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->getJobs();
+    }
+
+    public function testGetJobByStatus()
+    {
+        $statusFilter = 'completed';
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                Resources::JOB . '?status=' . $statusFilter,
+                Interfaced::METHOD_GET,
+                null,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->getJobsByStatus($statusFilter);
+    }
+
+    public function testPostJob()
+    {
+        $job = [
+            'process' => true,
+            'input' => [
+                [
+                    'type'   => 'remote',
+                    'source' => 'http://www.online-convert.com',
+                ],
+            ],
+        ];
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                Resources::JOB,
+                Interfaced::METHOD_POST,
+                $job
+            );
+
+        $this->jobsEndpoint->postJob($job);
+    }
+
+    public function testPatchJob()
+    {
+        $job = [
+            'process' => true,
+        ];
+
+        $urlToCall = ClientResources::HTTP_HOST . '/jobs/' . $this->aJobId;
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('generateUrl')
+            ->with(
+                Resources::JOB_ID,
+                ['job_id' => $this->aJobId]
+            )
+            ->willReturn($urlToCall);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $urlToCall,
+                Interfaced::METHOD_PATCH,
+                $job,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->patchJob($this->aJobId, $job);
+    }
+
+    public function testDeleteJob()
+    {
+        $urlToCall =  '/jobs/' . $this->aJobId;
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('generateUrl')
+            ->with(
+                Resources::JOB_ID,
+                ['job_id' => $this->aJobId]
+            )
+            ->willReturn($urlToCall);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $urlToCall,
+                Interfaced::METHOD_DELETE,
+                [],
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $response = $this->jobsEndpoint->deleteJob($this->aJobId);
+
+        $this->assertTrue($response);
+    }
+
+    public function testGetJobThreads()
+    {
+        $urlToCall =  '/jobs/' . $this->aJobId. '/threads';
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('generateUrl')
+            ->with(
+                Resources::JOB_ID_THREADS,
+                ['job_id' => $this->aJobId]
+            )
+            ->willReturn($urlToCall);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $urlToCall,
+                Interfaced::METHOD_GET,
+                null,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->getJobThreads($this->aJobId);
+    }
+
+    public function testGetJobHistory()
+    {
+        $urlToCall =  '/jobs/' . $this->aJobId. '/history';
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('generateUrl')
+            ->with(
+                Resources::JOB_ID_HISTORY,
+                ['job_id' => $this->aJobId]
+            )
+            ->willReturn($urlToCall);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $urlToCall,
+                Interfaced::METHOD_GET,
+                null,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->getJobHistory($this->aJobId);
+    }
+}

--- a/tests/Model/JobStatusTest.php
+++ b/tests/Model/JobStatusTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Test\OnlineConvert\Endpoint;
+
+use OnlineConvert\Model\JobStatus;
+
+/**
+ * Class JobStatusTest
+ * @package Test\OnlineConvert\Endpoint
+ */
+class JobStatusTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider for testStatus
+     *
+     * @return array
+     */
+    public function statusProvider()
+    {
+        return [
+            'Testing status "incomplete"' => [
+                'status'            => 'incomplete',
+                'canBeUpdatedBy'    => 'ready',
+                'canNotBeUpdatedBy' => null,
+                'isCompleted'       => false,
+                'isFailed'          => false,
+            ],
+            'Testing status "ready"' => [
+                'status'            => 'ready',
+                'canBeUpdatedBy'    => 'downloading',
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => false,
+                'isFailed'          => false,
+            ],
+            'Testing status "downloading"' => [
+                'status'            => 'downloading',
+                'canBeUpdatedBy'    => 'processing',
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => false,
+                'isFailed'          => false,
+            ],
+            'Testing status "processing"' => [
+                'status'            => 'processing',
+                'canBeUpdatedBy'    => 'completed',
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => false,
+                'isFailed'          => false,
+            ],
+            'Testing status "failed"' => [
+                'status'            => 'failed',
+                'canBeUpdatedBy'    => 'completed',
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => false,
+                'isFailed'          => true,
+            ],
+            'Testing status "completed"' => [
+                'status'            => 'completed',
+                'canBeUpdatedBy'    => null,
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => true,
+                'isFailed'          => false,
+            ],
+        ];
+    }
+
+    /**
+     * Test Status behavior
+     *
+     * @dataProvider statusProvider
+     *
+     * @param string  $statusCode
+     * @param string  $canBeUpdatedByCode
+     * @param string  $canNotBeUpdatedByCode
+     * @param boolean $isCompleted
+     * @param boolean $isFailed
+     */
+    public function testStatus($statusCode, $canBeUpdatedByCode, $canNotBeUpdatedByCode, $isCompleted, $isFailed)
+    {
+        $status = new JobStatus($statusCode);
+
+        $this->assertEquals($statusCode, $status->getCode());
+        $this->assertEquals($isCompleted, $status->isCompleted());
+        $this->assertEquals($isFailed, $status->isFailed());
+
+        if ($canBeUpdatedByCode) {
+            $canBeUpdatedBy = new JobStatus($canBeUpdatedByCode);
+            $this->assertTrue($status->canBeUpdated($canBeUpdatedBy));
+        }
+
+        if ($canNotBeUpdatedByCode) {
+            $canNotBeUpdatedBy = new JobStatus($canNotBeUpdatedByCode);
+            $this->assertFalse($status->canBeUpdated($canNotBeUpdatedBy));
+        }
+    }
+
+    public function testUnknownStatus()
+    {
+        $wrongStatus = 'wrongStatus';
+
+        $this->expectException('OnlineConvert\Exception\StatusUnknownException');
+        $this->expectExceptionMessage('Unknown status: ' . $wrongStatus);
+
+        new JobStatus($wrongStatus);
+    }
+
+    public function testIsStatus()
+    {
+        $status = new JobStatus(JobStatus::STATUS_PROCESSING);
+
+        $this->assertTrue($status->isStatus(JobStatus::STATUS_PROCESSING));
+        $this->assertFalse($status->isStatus(JobStatus::STATUS_READY));
+        $this->assertFalse($status->isStatus(JobStatus::STATUS_COMPLETED));
+    }
+}


### PR DESCRIPTION
Fixed an error that would make a php process run forever when a job status is more advanced in the work flow than the one we are waiting for.
Added unit tests.

> Should release a new major version as this PR introduces BC breaks.