### PR TITLE
Fixed loop in waitStatus

### DIFF
--- a/src/Endpoint/Abstracted.php
+++ b/src/Endpoint/Abstracted.php
@@ -48,6 +48,8 @@ class Abstracted
 
     /**
      * @param string $userToken
+     *
+     * @return $this
      */
     public function setUserToken($userToken)
     {

--- a/src/Endpoint/JobsEndpoint.php
+++ b/src/Endpoint/JobsEndpoint.php
@@ -248,7 +248,7 @@ class JobsEndpoint extends Abstracted
                     ' can never be reached since the actual status is ' . $actualStatus->getCode());
             }
 
-            if ($actualStatus->isFailed()) {
+            if ($actualStatus->isStatus(JobStatus::STATUS_FAILED)) {
                 throw new JobFailedException(json_encode($response));
             }
 

--- a/src/Endpoint/JobsEndpoint.php
+++ b/src/Endpoint/JobsEndpoint.php
@@ -1,10 +1,15 @@
 <?php
+
 namespace OnlineConvert\Endpoint;
 
 use OnlineConvert\Client\Interfaced;
 use OnlineConvert\Exception\CallbackNotDefinedException;
+use OnlineConvert\Exception\InvalidArgumentException;
+use OnlineConvert\Exception\InvalidStatusException;
 use OnlineConvert\Exception\JobFailedException;
+use OnlineConvert\Exception\JobNotFoundException;
 use OnlineConvert\Exception\OnlineConvertSdkException;
+use OnlineConvert\Model\JobStatus;
 
 /**
  * Manage Jobs Endpoint
@@ -19,6 +24,7 @@ class JobsEndpoint extends Abstracted
      * Status when the job finish correctly
      *
      * @const string
+     * @deprecated Will be removed in v3.0
      */
     const STATUS_COMPLETED = 'completed';
 
@@ -26,6 +32,7 @@ class JobsEndpoint extends Abstracted
      * Status when the job fails
      *
      * @const string
+     * @deprecated Will be removed in v3.0
      */
     const STATUS_FAILED = 'failed';
 
@@ -33,6 +40,7 @@ class JobsEndpoint extends Abstracted
      * Status when the job is ready to begin process
      *
      * @const string
+     * @deprecated Will be removed in v3.0
      */
     const STATUS_READY = 'ready';
 
@@ -40,8 +48,19 @@ class JobsEndpoint extends Abstracted
      * Status when the job is incomplete waiting for information to be ready or processed
      *
      * @const string
+     * @deprecated Will be removed in v3.0
      */
     const STATUS_INCOMPLETE = 'incomplete';
+
+    /**
+     * Default time in seconds to wait between job status requests
+     */
+    const DEFAULT_WAITING_TIME_BETWEEN_REQUESTS = 1;
+
+    /**
+     * Maximum time allowed for a status to be reached (14400 = 4 hours)
+     */
+    const MAX_WAITING_TIME = 14400;
 
     /**
      * Determine if this API Handler will be async or sync
@@ -52,11 +71,12 @@ class JobsEndpoint extends Abstracted
 
     /**
      * Post a full job
-     * Notice that this handle the 'process' flag in the job automatically
+     * Notice that this handles the 'process' flag in the job automatically
      *
      * @api
      *
-     * @throws OnlineConvertSdkException when error on the request
+     * @throws OnlineConvertSdkException When there is an error on the request
+     * @throws InvalidArgumentException  If the passed job missed mandatory fields
      *
      * @param array $job
      *
@@ -64,6 +84,17 @@ class JobsEndpoint extends Abstracted
      */
     public function postFullJob(array $job)
     {
+        if (empty($job)) {
+            throw new InvalidArgumentException('The Job is empty');
+        }
+
+        if (empty($job['input'])) {
+            throw new InvalidArgumentException(
+                'It is not possible to use ' . __METHOD__ .
+                ' with no input. Please, use ' . __CLASS__ . '::postIncompleteJob instead.'
+            );
+        }
+
         $this->checkJobCallbackForAsync($job);
 
         $uploadInput = [];
@@ -92,10 +123,10 @@ class JobsEndpoint extends Abstracted
         );
 
         if ($withUpload) {
-            $statusToWait = [self::STATUS_READY];
+            $statusToWait = [JobStatus::STATUS_READY];
 
             if (count($remoteInput) == 0) {
-                $statusToWait[] = self::STATUS_INCOMPLETE;
+                $statusToWait[] = JobStatus::STATUS_INCOMPLETE;
             }
 
             $job = $this->waitStatus($job['id'], $statusToWait);
@@ -104,7 +135,7 @@ class JobsEndpoint extends Abstracted
                 $this->postFile($input, $job);
             }
 
-            $job = $this->waitStatus($job['id'], [self::STATUS_READY]);
+            $job = $this->waitStatus($job['id'], [JobStatus::STATUS_READY]);
 
             $url = $this->client->generateUrl(Resources::JOB_ID, ['job_id' => $job['id']]);
 
@@ -115,7 +146,7 @@ class JobsEndpoint extends Abstracted
         }
 
         if (!$this->async) {
-            $this->waitStatus($job['id'], [self::STATUS_COMPLETED]);
+            $this->waitStatus($job['id'], [JobStatus::STATUS_COMPLETED]);
         }
 
         return $this->getJob($job['id']);
@@ -145,30 +176,58 @@ class JobsEndpoint extends Abstracted
     }
 
     /**
-     * Loop to check if the job finish
+     * Loop to check if the job has a specific or a later status
      *
      * @api
      *
-     * @throws OnlineConvertSdkException when error on the requests
+     * @throws OnlineConvertSdkException When an error was catched on the API request
+     * @throws JobFailedException        If the Job failed, regardless of the awaited statuses
+     * @throws JobNotFoundException      If the passed Job is missed or incomplete
+     * @throws InvalidArgumentException  When the method is called with wrong arguments
+     * @throws InvalidStatusException    When the awaited statuses cannot be reached anymore
      *
-     * @param string $jobId
-     * @param array  $waitTo      array with all the possibles status to wait
-     * @param int    $waitingTime time to wait between request in seconds
+     * @param string  $jobId                      The job id
+     * @param array   $waitFor                    Array containing all the possibles statuses to wait for
+     * @param integer $waitingTimeBetweenRequests Time to wait between requests in seconds
+     * @param integer $timeout                    Maximum time to wait for a status to be reached
      *
      * @return array
      */
-    public function waitStatus($jobId, array $waitTo, $waitingTime = 1)
-    {
-        if ($waitingTime < 1) {
-            $waitingTime = 1;
+    public function waitStatus(
+        $jobId,
+        array $waitFor,
+        $waitingTimeBetweenRequests = self::DEFAULT_WAITING_TIME_BETWEEN_REQUESTS,
+        $timeout = self::MAX_WAITING_TIME
+    ) {
+        if (empty($jobId)) {
+            throw new JobNotFoundException();
         }
+
+        if (empty($waitFor)) {
+            throw new InvalidArgumentException('No statuses provided to wait for');
+        }
+
+        $waitingTimeBetweenRequests = (int) $waitingTimeBetweenRequests;
+        $waitingTimeBetweenRequests = ($waitingTimeBetweenRequests >= 1) ?
+            $waitingTimeBetweenRequests :
+            self::DEFAULT_WAITING_TIME_BETWEEN_REQUESTS;
+
+        $timeout = (int) $timeout;
+        $timeout = ($timeout <= self::MAX_WAITING_TIME) ?
+            $timeout :
+            self::MAX_WAITING_TIME;
 
         $response        = null;
         $url             = $this->client->generateUrl(Resources::JOB_ID, ['job_id' => $jobId]);
-        $responseAsArray = [];
+
+        $higherAwaitedStatus = new JobStatus(JobStatus::STATUS_INCOMPLETE);
+        foreach ($waitFor as $awaitedStatusCode) {
+            $newStatus = new JobStatus($awaitedStatusCode);
+            $higherAwaitedStatus = $higherAwaitedStatus->canBeUpdated($newStatus) ? $newStatus : $higherAwaitedStatus;
+        }
 
         $i = 0;
-        while ($i < 14400) {
+        do {
             $response = $this->client->sendRequest(
                 $url,
                 Interfaced::METHOD_GET,
@@ -177,28 +236,36 @@ class JobsEndpoint extends Abstracted
             );
 
             $responseAsArray = $this->responseToArray($response);
-            $status          = $responseAsArray['status']['code'];
+            $actualStatus    = new JobStatus($responseAsArray['status']['code']);
 
-            if (in_array($status, $waitTo)) {
+            if (in_array($actualStatus->getCode(), $waitFor, true)) {
                 return $responseAsArray;
-            } elseif ($status == self::STATUS_FAILED) {
+            }
+
+            if (!$actualStatus->canBeUpdated($higherAwaitedStatus)) {
+                throw new InvalidStatusException(
+                    'The awaited status ' . $higherAwaitedStatus->getCode() .
+                    ' can never be reached since the actual status is ' . $actualStatus->getCode());
+            }
+
+            if ($actualStatus->isFailed()) {
                 throw new JobFailedException(json_encode($response));
             }
 
-            sleep($waitingTime);
-            $i += $waitingTime;
-        }
+            sleep($waitingTimeBetweenRequests);
+            $i += $waitingTimeBetweenRequests;
+        } while ($i <= $timeout);
 
-        return $responseAsArray;
+        throw new OnlineConvertSdkException('Timeout reached while waiting for the Job status');
     }
-
 
     /**
      * Start to process a job
      *
      * @api
      *
-     * @throws OnlineConvertSdkException when error on the request
+     * @throws OnlineConvertSdkException When error on the request
+     * @throws JobNotFoundException      If the passed Job is missed or incomplete
      *
      * @param array $job if this is not defined will take the last one created
      *
@@ -206,9 +273,13 @@ class JobsEndpoint extends Abstracted
      */
     public function processJob(array $job)
     {
+        if (empty($job['id'])) {
+            throw new JobNotFoundException();
+        }
+
         $job['process'] = true;
 
-        $this->waitStatus($job['id'], [self::STATUS_READY, self::STATUS_INCOMPLETE]);
+        $this->waitStatus($job['id'], [JobStatus::STATUS_READY, JobStatus::STATUS_INCOMPLETE]);
 
         $url = $this->client->generateUrl(Resources::JOB_ID, ['job_id' => $job['id']]);
         $this->client->sendRequest(
@@ -218,17 +289,11 @@ class JobsEndpoint extends Abstracted
             [Interfaced::HEADER_OC_JOB_TOKEN => $this->userToken]
         );
 
-        $url = $this->client->generateUrl(Resources::JOB_ID, ['job_id' => $job['id']]);
-        $this->client->sendRequest(
-            $url,
-            Interfaced::METHOD_GET,
-            null,
-            [Interfaced::HEADER_OC_JOB_TOKEN => $this->userToken]
-        );
-
         if (!$this->async) {
-            $this->waitStatus($job['id'], [self::STATUS_COMPLETED]);
+            return $this->waitStatus($job['id'], [JobStatus::STATUS_COMPLETED]);
         }
+
+        $url = $this->client->generateUrl(Resources::JOB_ID, ['job_id' => $job['id']]);
 
         return $this->responseToArray(
             $this->client->sendRequest(

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OnlineConvert\Exception;
+
+/**
+ * Throwable when the requested method receives bad arguments.
+ *
+ * @package OnlineConvert\Exception
+ */
+class InvalidArgumentException extends OnlineConvertSdkException
+{
+}

--- a/src/Exception/InvalidStatusException.php
+++ b/src/Exception/InvalidStatusException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OnlineConvert\Exception;
+
+/**
+ * Throwable when the requested status cannot be used in the actual context.
+ * E.g. if you try to patch a completed job
+ *
+ * @package OnlineConvert\Exception
+ */
+class InvalidStatusException extends OnlineConvertSdkException
+{
+}

--- a/src/Exception/JobNotFoundException.php
+++ b/src/Exception/JobNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OnlineConvert\Exception;
+
+/**
+ * Throwable when the job is not found
+ *
+ * @package OnlineConvert\Exception
+ */
+class JobNotFoundException extends OnlineConvertSdkException
+{
+}

--- a/src/Exception/StatusUnknownException.php
+++ b/src/Exception/StatusUnknownException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OnlineConvert\Exception;
+
+/**
+ * Throwable when the requested job status is unknown
+ *
+ * @package OnlineConvert\Exception
+ */
+class StatusUnknownException extends OnlineConvertSdkException
+{
+}

--- a/src/Handler/CallbackHandler.php
+++ b/src/Handler/CallbackHandler.php
@@ -1,19 +1,16 @@
 <?php
 namespace OnlineConvert\Handler;
 
-use OnlineConvert\Endpoint\JobsEndpoint;
 use OnlineConvert\Exception\JobFailedException;
+use OnlineConvert\Model\JobStatus;
 
 /**
  * Manage callbacks when the job finish given by the api
  *
  * @package OnlineConvert\Handler
- *
- * @author Andrés Cevallos <a.cevallos@qaamgo.com>
  */
 class CallbackHandler
 {
-
     /**
      * Check if the job given have status completed
      *
@@ -25,7 +22,7 @@ class CallbackHandler
      */
     public function jobHasExpectedStatus(array $job)
     {
-        if ($job['status']['code'] != JobsEndpoint::STATUS_COMPLETED) {
+        if ($job['status']['code'] != JobStatus::STATUS_COMPLETED) {
             $jobId = $job['id'];
             throw new JobFailedException("the job '$jobId' has not been completed successfully");
         }

--- a/src/Model/JobStatus.php
+++ b/src/Model/JobStatus.php
@@ -124,26 +124,6 @@ class JobStatus
     }
 
     /**
-     * Checks if the status is completed
-     *
-     * @return boolean
-     */
-    public function isCompleted()
-    {
-        return ($this->code === self::STATUS_COMPLETED);
-    }
-
-    /**
-     * Checks if the status is failed
-     *
-     * @return boolean
-     */
-    public function isFailed()
-    {
-        return ($this->code === self::STATUS_FAILED);
-    }
-
-    /**
      * @return string
      */
     public function getCode()

--- a/src/Model/JobStatus.php
+++ b/src/Model/JobStatus.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace OnlineConvert\Model;
+
+use OnlineConvert\Exception\StatusUnknownException;
+
+/**
+ * Class Status
+ *
+ * @package OnlineConvert\Model
+ */
+class JobStatus
+{
+    /**
+     * Status when the job is incomplete waiting for information to be ready or processed
+     *
+     * @const string
+     */
+    const STATUS_INCOMPLETE = 'incomplete';
+
+    /**
+     * Status when the job is ready to begin process
+     *
+     * @const string
+     */
+    const STATUS_READY = 'ready';
+
+    /**
+     * Status when the job is downloading the input files
+     *
+     * @const string
+     */
+    const STATUS_DOWNLOADING = 'downloading';
+
+    /**
+     * Status when the job is processing the job
+     *
+     * @const string
+     */
+    const STATUS_PROCESSING = 'processing';
+
+    /**
+     * Status when the job fails
+     *
+     * @const string
+     */
+    const STATUS_FAILED = 'failed';
+
+    /**
+     * Status when the job completes correctly
+     *
+     * @const string
+     */
+    const STATUS_COMPLETED = 'completed';
+
+    /**
+     * The status ranking list.
+     * A status can be updated only if the new one is at the same or at a higher ranking level.
+     *
+     * @var array
+     */
+    private $statusesRanking = [
+        self::STATUS_INCOMPLETE  => 1,
+        self::STATUS_READY       => 2,
+        self::STATUS_DOWNLOADING => 2,
+        self::STATUS_PROCESSING  => 3,
+        self::STATUS_FAILED      => 4,
+        self::STATUS_COMPLETED   => 5,
+    ];
+
+    /**
+     * The status code
+     *
+     * @var string
+     */
+    private $code;
+
+    /**
+     * The status ranking level
+     *
+     * @var integer
+     */
+    private $rank;
+
+    /**
+     * Status constructor.
+     *
+     * @param string $statusCode
+     */
+    public function __construct($statusCode)
+    {
+        if (empty($this->statusesRanking[$statusCode])) {
+            throw new StatusUnknownException('Unknown status: ' . $statusCode);
+        }
+
+        $this->code = $statusCode;
+        $this->rank = $this->statusesRanking[$statusCode];
+    }
+
+    /**
+     * Checks if the job status can be updated with the passed one
+     *
+     * @param JobStatus $newStatus    The new desired status
+     *
+     * @return boolean                True when it is possible to update the actual status with the passed one
+     *
+     * @throws StatusUnknownException When one of the passed statuses is unknown
+     */
+    public function canBeUpdated(JobStatus $newStatus)
+    {
+        return ($newStatus->getRank() >= $this->rank);
+    }
+
+    /**
+     * Checks if the status is equal to the one passed (one of self::STATUS_*)
+     *
+     * @param string $status
+     *
+     * @return boolean
+     */
+    public function isStatus($status)
+    {
+        return ($this->code === $status);
+    }
+
+    /**
+     * Checks if the status is completed
+     *
+     * @return boolean
+     */
+    public function isCompleted()
+    {
+        return ($this->code === self::STATUS_COMPLETED);
+    }
+
+    /**
+     * Checks if the status is failed
+     *
+     * @return boolean
+     */
+    public function isFailed()
+    {
+        return ($this->code === self::STATUS_FAILED);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getRank()
+    {
+        return $this->rank;
+    }
+}

--- a/tests/Endpoint/Abstracted.php
+++ b/tests/Endpoint/Abstracted.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Test\OnlineConvert\Endpoint;
+
+use OnlineConvert\Client\Interfaced;
+
+class Abstracted extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $clientMock;
+
+    /**
+     * A Job id in UUID format
+     *
+     * @var string
+     */
+    protected $aJobId = '00000000-1111-2222-3333-444444444444';
+
+    /**
+     * A Conversion id in UUID format
+     *
+     * @var string
+     */
+    protected $aConversionId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+    /**
+     * A token
+     *
+     * @var string
+     */
+    protected $aToken = '01234567890123456789012345678901';
+
+    /**
+     * A server URL
+     *
+     * @var string
+     */
+    protected $aServer = 'http://www4.online-convert.com';
+
+    /**
+     * Method called before starting each test
+     */
+    public function setUp()
+    {
+        $this->clientMock = $this->getMockBuilder(Interfaced::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Method called at the end of each test
+     */
+    public function tearDown()
+    {
+        unset($this->clientMock);
+    }
+
+    /**
+     * To be used while checking for invalid arguments to be sure that no HTTP API requests are sent
+     */
+    protected function setClientMockToNeverCallMethods()
+    {
+        $this->clientMock
+            ->expects($this->never())
+            ->method('generateUrl');
+        $this->clientMock
+            ->expects($this->never())
+            ->method('sendRequest');
+    }
+}

--- a/tests/Endpoint/JobsEndpointTest.php
+++ b/tests/Endpoint/JobsEndpointTest.php
@@ -1,0 +1,379 @@
+<?php
+
+namespace Test\OnlineConvert\Endpoint;
+
+use OnlineConvert\Client\Interfaced;
+use OnlineConvert\Client\Resources as ClientResources;
+use OnlineConvert\Endpoint\JobsEndpoint;
+use OnlineConvert\Endpoint\Resources;
+
+/**
+ * Class JobsEndpointTest
+ * @package Test\OnlineConvert\Endpoint
+ */
+class JobsEndpointTest extends Abstracted
+{
+    /**
+     * @var JobsEndpoint
+     */
+    private $jobsEndpoint;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->jobsEndpoint = new JobsEndpoint($this->clientMock);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        unset($this->jobsEndpoint);
+    }
+
+    public function testWaitStatusForMatchedSingleStatus()
+    {
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"ready"}}');
+
+        $response = $this->jobsEndpoint->waitStatus($this->aJobId, ['ready']);
+
+        $this->assertEquals('ready', $response['status']['code']);
+    }
+
+    public function testWaitStatusForMatchedMultipleStatuses()
+    {
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"downloading"}}');
+
+        $response = $this->jobsEndpoint->waitStatus($this->aJobId, ['ready', 'downloading', 'completed']);
+
+        $this->assertEquals('downloading', $response['status']['code']);
+    }
+
+    public function testWaitStatusForLowerStatus()
+    {
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"processing"}}');
+
+        $this->expectException('OnlineConvert\Exception\InvalidStatusException');
+        $this->expectExceptionMessage(
+            'The awaited status ready can never be reached since the actual status is processing'
+        );
+
+        $this->jobsEndpoint->waitStatus($this->aJobId, ['ready']);
+    }
+
+    public function testWaitStatusForLowerStatusButJobFailed()
+    {
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"failed"}}');
+
+        $this->expectException('OnlineConvert\Exception\JobFailedException');
+        $this->expectExceptionMessage(
+            '"{\"id\":\"' . $this->aJobId . '\",\"status\":{\"code\":\"failed\"}}"'
+        );
+
+        $this->jobsEndpoint->waitStatus($this->aJobId, ['completed']);
+    }
+
+    public function testWaitStatusForHigherStatus()
+    {
+        $this->clientMock
+            ->expects($this->at(0))
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"downloading"}}');
+        $this->clientMock
+            ->expects($this->at(1))
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"processing"}}');
+        $this->clientMock
+            ->expects($this->at(2))
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"completed"}}');
+
+        $response = $this->jobsEndpoint->waitStatus($this->aJobId, ['completed']);
+
+        $this->assertEquals('completed', $response['status']['code']);
+    }
+
+    public function testWaitStatusForTimeoutException()
+    {
+        $waitingTimeBetweenRequests = 1;
+        $timeout                    = 2;
+
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"ready"}}');
+
+        $this->expectException('OnlineConvert\Exception\OnlineConvertSdkException');
+        $this->expectExceptionMessage('Timeout reached while waiting for the Job status');
+
+        $response = $this->jobsEndpoint->waitStatus(
+            $this->aJobId,
+            ['completed'],
+            $waitingTimeBetweenRequests,
+            $timeout
+        );
+
+        $this->assertEquals('ready', $response['status']['code']);
+    }
+
+    public function testPostFullJobWithEmptyJob()
+    {
+        $this->expectException('OnlineConvert\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('The Job is empty');
+
+        $this->setClientMockToNeverCallMethods();
+
+        $this->jobsEndpoint->postFullJob([]);
+    }
+
+    public function testPostFullJobWithEmptyInput()
+    {
+        $job = [
+            'process' => false,
+        ];
+
+        $this->setClientMockToNeverCallMethods();
+
+        $this->expectException('OnlineConvert\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage(
+            'It is not possible to use OnlineConvert\Endpoint\JobsEndpoint::postFullJob with no input. ' .
+            'Please, use OnlineConvert\Endpoint\JobsEndpoint::postIncompleteJob instead.'
+        );
+
+        $this->jobsEndpoint->postFullJob($job);
+    }
+
+    public function testPostFullJobAsyncWithoutCallback()
+    {
+        $job = [
+            'process' => false,
+            'input' => [
+                [
+                    'type'   => 'remote',
+                    'source' => 'http://www.online-convert.com',
+                ],
+            ],
+        ];
+
+        $this->setClientMockToNeverCallMethods();
+
+        $this->expectException('OnlineConvert\Exception\CallbackNotDefinedException');
+        $this->expectExceptionMessage('Async jobs must have a valid callback url to notify when the job finish');
+
+        $this->jobsEndpoint->setAsync(true);
+        $this->jobsEndpoint->postFullJob($job);
+    }
+
+    public function testPostFullJobWithRemoteInput()
+    {
+        $job = [
+            'process' => true,
+            'input' => [
+                [
+                    'type'   => 'remote',
+                    'source' => 'http://www.online-convert.com',
+                ],
+            ],
+        ];
+
+        $this->clientMock
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->willReturn('{"id":"' . $this->aJobId . '","status":{"code":"completed"}}');
+
+        $this->jobsEndpoint->postFullJob($job);
+    }
+
+    public function testPostIncompleteSyncJobWillChangeProcessToFalse()
+    {
+        $job = [
+            'process' => true,
+        ];
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(Resources::JOB, Interfaced::METHOD_POST, ['process' => false]);
+
+        $this->jobsEndpoint->postIncompleteJob($job);
+    }
+
+    public function testGetJobs()
+    {
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                Resources::JOB,
+                Interfaced::METHOD_GET,
+                null,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->getJobs();
+    }
+
+    public function testGetJobByStatus()
+    {
+        $statusFilter = 'completed';
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                Resources::JOB . '?status=' . $statusFilter,
+                Interfaced::METHOD_GET,
+                null,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->getJobsByStatus($statusFilter);
+    }
+
+    public function testPostJob()
+    {
+        $job = [
+            'process' => true,
+            'input' => [
+                [
+                    'type'   => 'remote',
+                    'source' => 'http://www.online-convert.com',
+                ],
+            ],
+        ];
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                Resources::JOB,
+                Interfaced::METHOD_POST,
+                $job
+            );
+
+        $this->jobsEndpoint->postJob($job);
+    }
+
+    public function testPatchJob()
+    {
+        $job = [
+            'process' => true,
+        ];
+
+        $urlToCall = ClientResources::HTTP_HOST . '/jobs/' . $this->aJobId;
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('generateUrl')
+            ->with(
+                Resources::JOB_ID,
+                ['job_id' => $this->aJobId]
+            )
+            ->willReturn($urlToCall);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $urlToCall,
+                Interfaced::METHOD_PATCH,
+                $job,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->patchJob($this->aJobId, $job);
+    }
+
+    public function testDeleteJob()
+    {
+        $urlToCall =  '/jobs/' . $this->aJobId;
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('generateUrl')
+            ->with(
+                Resources::JOB_ID,
+                ['job_id' => $this->aJobId]
+            )
+            ->willReturn($urlToCall);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $urlToCall,
+                Interfaced::METHOD_DELETE,
+                [],
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $response = $this->jobsEndpoint->deleteJob($this->aJobId);
+
+        $this->assertTrue($response);
+    }
+
+    public function testGetJobThreads()
+    {
+        $urlToCall =  '/jobs/' . $this->aJobId. '/threads';
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('generateUrl')
+            ->with(
+                Resources::JOB_ID_THREADS,
+                ['job_id' => $this->aJobId]
+            )
+            ->willReturn($urlToCall);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $urlToCall,
+                Interfaced::METHOD_GET,
+                null,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->getJobThreads($this->aJobId);
+    }
+
+    public function testGetJobHistory()
+    {
+        $urlToCall =  '/jobs/' . $this->aJobId. '/history';
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('generateUrl')
+            ->with(
+                Resources::JOB_ID_HISTORY,
+                ['job_id' => $this->aJobId]
+            )
+            ->willReturn($urlToCall);
+
+        $this->clientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with(
+                $urlToCall,
+                Interfaced::METHOD_GET,
+                null,
+                [Interfaced::HEADER_OC_JOB_TOKEN => null]
+            );
+
+        $this->jobsEndpoint->getJobHistory($this->aJobId);
+    }
+}

--- a/tests/Model/JobStatusTest.php
+++ b/tests/Model/JobStatusTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Test\OnlineConvert\Endpoint;
+
+use OnlineConvert\Model\JobStatus;
+
+/**
+ * Class JobStatusTest
+ * @package Test\OnlineConvert\Endpoint
+ */
+class JobStatusTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider for testStatus
+     *
+     * @return array
+     */
+    public function statusProvider()
+    {
+        return [
+            'Testing status "incomplete"' => [
+                'status'            => 'incomplete',
+                'canBeUpdatedBy'    => 'ready',
+                'canNotBeUpdatedBy' => null,
+                'isCompleted'       => false,
+                'isFailed'          => false,
+            ],
+            'Testing status "ready"' => [
+                'status'            => 'ready',
+                'canBeUpdatedBy'    => 'downloading',
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => false,
+                'isFailed'          => false,
+            ],
+            'Testing status "downloading"' => [
+                'status'            => 'downloading',
+                'canBeUpdatedBy'    => 'processing',
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => false,
+                'isFailed'          => false,
+            ],
+            'Testing status "processing"' => [
+                'status'            => 'processing',
+                'canBeUpdatedBy'    => 'completed',
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => false,
+                'isFailed'          => false,
+            ],
+            'Testing status "failed"' => [
+                'status'            => 'failed',
+                'canBeUpdatedBy'    => 'completed',
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => false,
+                'isFailed'          => true,
+            ],
+            'Testing status "completed"' => [
+                'status'            => 'completed',
+                'canBeUpdatedBy'    => null,
+                'canNotBeUpdatedBy' => 'incomplete',
+                'isCompleted'       => true,
+                'isFailed'          => false,
+            ],
+        ];
+    }
+
+    /**
+     * Test Status behavior
+     *
+     * @dataProvider statusProvider
+     *
+     * @param string  $statusCode
+     * @param string  $canBeUpdatedByCode
+     * @param string  $canNotBeUpdatedByCode
+     * @param boolean $isCompleted
+     * @param boolean $isFailed
+     */
+    public function testStatus($statusCode, $canBeUpdatedByCode, $canNotBeUpdatedByCode, $isCompleted, $isFailed)
+    {
+        $status = new JobStatus($statusCode);
+
+        $this->assertEquals($statusCode, $status->getCode());
+        $this->assertEquals($isCompleted, $status->isCompleted());
+        $this->assertEquals($isFailed, $status->isFailed());
+
+        if ($canBeUpdatedByCode) {
+            $canBeUpdatedBy = new JobStatus($canBeUpdatedByCode);
+            $this->assertTrue($status->canBeUpdated($canBeUpdatedBy));
+        }
+
+        if ($canNotBeUpdatedByCode) {
+            $canNotBeUpdatedBy = new JobStatus($canNotBeUpdatedByCode);
+            $this->assertFalse($status->canBeUpdated($canNotBeUpdatedBy));
+        }
+    }
+
+    public function testUnknownStatus()
+    {
+        $wrongStatus = 'wrongStatus';
+
+        $this->expectException('OnlineConvert\Exception\StatusUnknownException');
+        $this->expectExceptionMessage('Unknown status: ' . $wrongStatus);
+
+        new JobStatus($wrongStatus);
+    }
+
+    public function testIsStatus()
+    {
+        $status = new JobStatus(JobStatus::STATUS_PROCESSING);
+
+        $this->assertTrue($status->isStatus(JobStatus::STATUS_PROCESSING));
+        $this->assertFalse($status->isStatus(JobStatus::STATUS_READY));
+        $this->assertFalse($status->isStatus(JobStatus::STATUS_COMPLETED));
+    }
+}

--- a/tests/Model/JobStatusTest.php
+++ b/tests/Model/JobStatusTest.php
@@ -79,8 +79,8 @@ class JobStatusTest extends \PHPUnit_Framework_TestCase
         $status = new JobStatus($statusCode);
 
         $this->assertEquals($statusCode, $status->getCode());
-        $this->assertEquals($isCompleted, $status->isCompleted());
-        $this->assertEquals($isFailed, $status->isFailed());
+        $this->assertEquals($isCompleted, $status->isStatus(JobStatus::STATUS_COMPLETED));
+        $this->assertEquals($isFailed, $status->isStatus(JobStatus::STATUS_FAILED));
 
         if ($canBeUpdatedByCode) {
             $canBeUpdatedBy = new JobStatus($canBeUpdatedByCode);


### PR DESCRIPTION
Added deprecation warnings for `STATUS_*` constants located inside the `JobsEndpoint` class, you should use the constants inside `JobStatus` class instead.