### PR TITLE
[BUGFIX] Patch process field only

### DIFF
--- a/src/Endpoint/JobsEndpoint.php
+++ b/src/Endpoint/JobsEndpoint.php
@@ -142,7 +142,7 @@ class JobsEndpoint extends Abstracted
 
             $job['process'] = true;
             $job            = $this->responseToArray(
-                $this->client->sendRequest($url, Interfaced::METHOD_PATCH, $job)
+                $this->client->sendRequest($url, Interfaced::METHOD_PATCH, ['process' => true])
             );
         }
 


### PR DESCRIPTION
Patch only the process field instead of the whole job object