### PR TITLE
 Added HTTP Response in RequestException 

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -1,13 +1,34 @@
 <?php
+
 namespace OnlineConvert\Exception;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
- * Throwable when the client have request error
+ * Thrown when the client has request errors
  *
  * @package OnlineConvert\Exception
- *
- * @author Andrés Cevallos <a.cevallos@qaamgo.com>
  */
 class RequestException extends OnlineConvertSdkException
 {
+    /**
+     * @var ResponseInterface
+     */
+    protected $response;
+
+    /**
+     * @param ResponseInterface $response
+     */
+    public function setResponse(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return ResponseInterface
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
 }

--- a/src/Helper/RequestHelper.php
+++ b/src/Helper/RequestHelper.php
@@ -78,7 +78,10 @@ class RequestHelper
                     $client
                 );
             } catch (GuzzleRequestException $e) {
-                throw new RequestException($e->getMessage());
+                $requestException = new RequestException($e->getMessage());
+                $requestException->setResponse($e->getResponse());
+
+                throw $requestException;
             }
         } else {
             try {
@@ -90,7 +93,10 @@ class RequestHelper
                     $client
                 );
             } catch (GuzzleRequestException $e) {
-                throw new RequestException($e->getMessage());
+                $requestException = new RequestException($e->getMessage());
+                $requestException->setResponse($e->getResponse());
+
+                throw $requestException;
             }
         }
 
@@ -141,7 +147,10 @@ class RequestHelper
                 $client
             );
         } catch (GuzzleRequestException $e) {
-            throw new RequestException($e->getMessage());
+            $requestException = new RequestException($e->getMessage());
+            $requestException->setResponse($e->getResponse());
+
+            throw $requestException;
         }
 
         return $request->getBody()->getContents();


### PR DESCRIPTION
Now the RequestException carries the HTTP full response which is a ResponseInterface object and it is accessible by calling the method getResponse()